### PR TITLE
[Feat] 베스트 책 조회 API 구현

### DIFF
--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/controller/BestController.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/controller/BestController.java
@@ -1,0 +1,36 @@
+package com.example.DOSOPTaladin.controller;
+
+
+import com.example.DOSOPTaladin.dto.response.best.BestBookResponse;
+import com.example.DOSOPTaladin.dto.response.main.EditorChoiceResponse;
+import com.example.DOSOPTaladin.service.BestService;
+import com.example.DOSOPTaladin.service.MainService;
+import com.example.DOSOPTaladin.util.BaseApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "BestController")
+@RequestMapping("/best")
+@RequiredArgsConstructor
+public class BestController {
+
+    private final BestService bestService;
+
+    @Operation(summary = "BEST 책 리스트 조회", description = "BEST 책 리스트 정보 불러오기 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "BEST 책 리스트 불러오기 완료", content = @Content(schema = @Schema(implementation = BestBookResponse.class))),
+    })
+    @GetMapping()
+    public BaseApiResponse<Object> getEditorChoice(){
+        return new BaseApiResponse<>("BEST 책 리스트 불러오기 완료", bestService.getBestBookList());
+    }
+}

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/controller/MainController.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/controller/MainController.java
@@ -27,7 +27,6 @@ public class MainController {
     @Operation(summary = "편집장의 선택 조회", description = "편집장의 선택 정보 불러오기 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "편집장의 선택 목록 불러오기 완료", content = @Content(schema = @Schema(implementation = EditorChoiceResponse.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 경로입니다.", content = @Content)
     })
     @GetMapping("/editorchoice")
     public BaseApiResponse<Object> getEditorChoice(){

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/domain/Book.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/domain/Book.java
@@ -1,6 +1,7 @@
 package com.example.DOSOPTaladin.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Null;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,6 +29,7 @@ public class Book extends BaseTimeEntity {
 
     private String writer;
 
+    @Column(nullable = true)
     private String painter;
 
     private String publisher;

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/dto/response/best/BestBookResponse.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/dto/response/best/BestBookResponse.java
@@ -1,0 +1,76 @@
+package com.example.DOSOPTaladin.dto.response.best;
+
+
+import com.example.DOSOPTaladin.domain.Book;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Schema(description = "베스트 도서 응답DTO")
+@Getter
+public class BestBookResponse{
+
+    private Long bookId;
+
+    private String imgUrl;
+
+    private String title;
+
+    private String subtitle;
+
+    private String writer;
+
+    private String painter;
+
+    private String publisher;
+
+    private String pubDate;
+
+    private double score;
+
+    private int tag;
+
+    private String discountPrice;
+
+    private String mileage;
+
+    private boolean heart;
+
+
+    public BestBookResponse() {}
+
+    public BestBookResponse(Book book, Boolean heartStatus) {
+        this.bookId = book.getId();
+        this.imgUrl = book.getImg();
+        this.title = book.getTitle();
+        this.subtitle = book.getSubTitle();
+        this.writer = book.getWriter();
+        this.painter = book.getPainter();
+        this.publisher = book.getPublisher();
+        this.pubDate = toDatePattern(book.getPubDate());
+        this.score = book.getScore();
+        this.tag = book.getTag();
+        this.discountPrice = toDiscountPrice(book.getPrice());
+        this.mileage = toMileage(book.getMileage());
+        this.heart = heartStatus;
+    }
+
+    private String toDatePattern(LocalDateTime date){
+        return date.format(DateTimeFormatter.ofPattern("yyyy년 MM월"));
+    }
+
+    private String toDiscountPrice(int price){
+        price = (int) Math.ceil(price * 0.9);
+        String won = Integer.toString(price);
+        return won.replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + "원";
+    }
+
+    private String toMileage(int price){
+        String won = Integer.toString(price);
+        return won.replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + "원";
+    }
+
+}

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/repository/HeartJpaRespository.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/repository/HeartJpaRespository.java
@@ -1,0 +1,14 @@
+package com.example.DOSOPTaladin.repository;
+
+import com.example.DOSOPTaladin.domain.Book;
+import com.example.DOSOPTaladin.domain.Heart;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HeartJpaRespository extends JpaRepository<Heart, Long> {
+
+    boolean existsByBook_Id(long bookId);
+
+}

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/service/BestService.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/service/BestService.java
@@ -1,0 +1,40 @@
+package com.example.DOSOPTaladin.service;
+
+import com.example.DOSOPTaladin.domain.Book;
+import com.example.DOSOPTaladin.domain.Heart;
+import com.example.DOSOPTaladin.dto.response.best.BestBookResponse;
+import com.example.DOSOPTaladin.dto.response.main.EditorChoiceResponse;
+import com.example.DOSOPTaladin.repository.BookJpaRepository;
+import com.example.DOSOPTaladin.repository.HeartJpaRespository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BestService {
+
+    private final BookJpaRepository bookJpaRepository;
+    private final HeartJpaRespository heartJpaRespository;
+
+    public List<BestBookResponse> getBestBookList() {
+        List<Book> books = bookJpaRepository.findAll();
+
+        List<BestBookResponse> bestBookResponseList = new ArrayList<BestBookResponse>();
+
+        for( Book book : books){
+            BestBookResponse bestBookResponse = new BestBookResponse();
+            bestBookResponse = new BestBookResponse(book, heartJpaRespository.existsByBook_Id(book.getId()));
+
+            bestBookResponseList.add(bestBookResponse);
+        }
+
+        return bestBookResponseList;
+    }
+}

--- a/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/util/error/BadRequestException.java
+++ b/DOSOPTaladin/src/main/java/com/example/DOSOPTaladin/util/error/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.example.DOSOPTaladin.util.error;
+
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(ErrorResponseStatus status){
+        super(status.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #5 

## 📌 좀 더 알아볼 것들 & 알게 된 것들
<!-- 좀 더 알아볼 것들 & 알게 된 것들 내용을 적어주세요 -->
1. 레코드는 인수가 없는 생성자를 생성하고 인수 목록이 있는 생성자를 선언하면 컴파일 에러가 발생한다고 하네요... record 사용해서 Dto 생성하고 싶었는데 빈 생성자가 생성이 안되서 그냥.. Class로 만들었답니다..ㅠ

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1. Book Entity에 그린이(painter) nullable = true로 설정해뒀습니다! ( 그린이 없을 경우에는 빈 String 출력)
2. BestBookResponse Dto에서 price 그냥 원가 인거 같아서, 할인가(10%) 계산해서 return 해줬습니다! 
3. BestService를 보면 heart에 book id가 존재하는지 아닌지에 따라 true, false로 반환 해주도록 하는게 맞는거 같아서 모든 책 마다 있는지 없는지 조회를 해야할것 같더라고요..! 그래서 반복문 돌려서 Heart 에 book id가 존재하는지 매번 조회했답니다 ㅠ 쿼리 많이 날라감 이슈


4.  ⭐️⭐️⭐️장바구니 개수도 return 해줘야하는데 따로 API 팔까요 아니면 해당 API에 같이 보낼까요..?
- 해당 API 에 같이 보낼 경우, 장바구니에 추가할때 마다 클라에서 API 새로 고침해서 다시 조회해야함 
   ㄴ 그러면 heart도 계속 새로 조회해서 쿼리가 너무 많이 날라가는 이슈..
- 따로 API를 파는 경우... 화면 로딩하는 처음에만 조회하고, 고객이 장바구니 버튼 눌렀을때 베스트뷰에는 개수가 추가 되는 기능만 있기 때문에 ( 장바구니에서 삭제는 지영이 뷰에 있음) 그 부분은 클라에서 숫자만 키워서 보여주면 될듯..? 근데 따로 파도 되는건지.. 일반적인 방법인지 모르겠네욤?

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="800" alt="스크린샷 2023-11-22 오후 10 49 36" src="https://github.com/SOPT-33th-Joint-Seminar-WEB-1/Server/assets/62981652/8f826817-a669-4579-9e83-f58b3571fda2">

painter가 없는 경우 빈 스트링 "" 값으로 날라감
<img width="800" alt="스크린샷 2023-11-22 오후 10 49 53" src="https://github.com/SOPT-33th-Joint-Seminar-WEB-1/Server/assets/62981652/decfef77-eee8-454d-bfde-cc880e87fc44">


<img width="933" alt="스크린샷 2023-11-22 오후 10 50 41" src="https://github.com/SOPT-33th-Joint-Seminar-WEB-1/Server/assets/62981652/097b07bb-8ccb-4025-b375-bb3bd3492575">


